### PR TITLE
Create the fonts directory (recursively) if it does not exist.

### DIFF
--- a/src/lib/dirs.rs
+++ b/src/lib/dirs.rs
@@ -1,5 +1,11 @@
 use std::env;
 use std::path::{Path, PathBuf};
+use std::fs::DirBuilder;
+use std::io;
+
+pub fn make_rec_dir(dir: &Path) -> io::Result<()> {
+  DirBuilder::new().recursive(true).create(dir)
+}
 
 pub fn font_cache() -> Option<PathBuf> {
     env::home_dir().map(|path| path.join(".local/share/fonts/"))

--- a/src/lib/fonts.rs
+++ b/src/lib/fonts.rs
@@ -28,6 +28,8 @@ impl FontsList {
 
         // Get the base directory of the local font directory
         let path = dirs::font_cache().ok_or(FontError::FontDirectory)?;
+        // Create the base directory of the local fonts
+        dirs::make_rec_dir(&path)?;
         // Find the given font in the font list and return it's reference.
         let font = self.get_family(family).ok_or(FontError::FontNotFound)?;
 


### PR DESCRIPTION
Currently fontfinder errors out if it cannot find ~/.local/share/fonts. This
change adds an attempt to recursively create the directory before storing the
font file.

It implements a helper function dirs::make_rec_dir and calls it from
FontsList::download.