### PR TITLE
Use dirs crate to avoid deprecation warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,7 @@ description = "Font Finder Library"
 license-file = "LICENSE"
 readme = "README.md"
 repository = "https://github.com/mmstick/fontfinder"
-version = "2.0.0"
-edition = "2018"
+version = "2.1.0"
 
 [workspace]
 members = ["gtk"]
@@ -24,3 +23,4 @@ rust-embed = "5.9"
 serde = { version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 ureq = { version = "2.1", features = ["json"]}
+dirs = "4.0.0"

--- a/src/dirs.rs
+++ b/src/dirs.rs
@@ -1,6 +1,7 @@
+extern crate dirs;
+
 use crate::fl;
 use anyhow::Context;
-use std::env;
 use std::fs::DirBuilder;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -13,7 +14,7 @@ pub fn recursively_create(dir: &Path) -> io::Result<()> {
 /// Obtains the path of the local font share, based on the current user's home
 /// directory.
 pub fn font_cache() -> anyhow::Result<PathBuf> {
-    env::home_dir()
+    dirs::home_dir()
         .map(|path| path.join(".local/share/fonts/"))
         .with_context(|| fl!("home-not-found"))
 }


### PR DESCRIPTION
Fix #26 - also increment version number since we performed changes